### PR TITLE
Enable callers to obtain error information from the app registration process

### DIFF
--- a/AppxUtilities/Start.ps1
+++ b/AppxUtilities/Start.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 $cwd = $args[0]
 $guid = $args[1]
 $appxmanifest = $args[2]

--- a/AppxUtilities/StartLh.ps1
+++ b/AppxUtilities/StartLh.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 $cwd = $args[0]
 $guid = $args[1]
 $appxmanifest = $args[2]

--- a/hwa.js
+++ b/hwa.js
@@ -45,9 +45,15 @@ function registerApp(manifest) {
       path.join(cwd, 'AppxUtilities/Start.ps1') +
       ' ' + cwd + ' ' + guid + ' ' + manifestloc + '"\'}";';
     }
-    exec(script,
-    function(err, stdout, stderr) {
-      console.log('launching app...');
+
+    return new Promise(function (resolve, reject) {
+      exec(script, function(err, stdout, stderr) {
+        if (err) {
+          return reject(err);
+        }
+
+        resolve(stdout);
+      });
     });
   }
 }

--- a/hwa.js
+++ b/hwa.js
@@ -36,9 +36,9 @@ function registerApp(manifest) {
     var sp = buffer.match(/\bStartPage="(.*?)"/)[1];
     var isLocalhost = sp.match(/https?:\/\/localhost:?\d*\/?$/); 
     
-    var script = 'powershell -noprofile -noninteractive -ExecutionPolicy Bypass -File "'
-                  + path.join(cwd, 'AppxUtilities/' + (isLocalhost ? 'StartLh.ps1' : 'Start.ps1')) + '"'
-                  + ' "' + cwd + '" "' + guid + '" "' + manifestloc + '"';
+    var script = 'powershell -noprofile -noninteractive -ExecutionPolicy Bypass -Command "'
+                  + path.join(cwd, 'AppxUtilities/' + (isLocalhost ? 'StartLh.ps1' : 'Start.ps1')) 
+                  + ' \'' + cwd + '\' \'' + guid + '\' \'' + manifestloc + '\'"';                  
     return new Promise(function (resolve, reject) {
       exec(script, function(err, stdout, stderr) {
         if (err) {

--- a/hwa.js
+++ b/hwa.js
@@ -36,7 +36,7 @@ function registerApp(manifest) {
     var sp = buffer.match(/\bStartPage="(.*?)"/)[1];
     var isLocalhost = sp.match(/https?:\/\/localhost:?\d*\/?$/); 
     
-    var script = 'powershell -noprofile -ExecutionPolicy Bypass -File "'
+    var script = 'powershell -noprofile -noninteractive -ExecutionPolicy Bypass -File "'
                   + path.join(cwd, 'AppxUtilities/' + (isLocalhost ? 'StartLh.ps1' : 'Start.ps1')) + '"'
                   + ' "' + cwd + '" "' + guid + '" "' + manifestloc + '"';
     return new Promise(function (resolve, reject) {

--- a/hwa.js
+++ b/hwa.js
@@ -31,21 +31,14 @@ function registerApp(manifest) {
   if (os.platform() === 'win32') {
     var manifestloc = manifest || appxmanifest;
     var cwd = path.normalize(__dirname);
-    //var guid = '122f1d07-66a9-427c-9fb4-80fa75b5d81a';
     var buffer = fs.readFileSync(manifestloc, 'utf8');
     var guid = buffer.match(/\bName="(.*?)"/)[1];
     var sp = buffer.match(/\bStartPage="(.*?)"/)[1];
-    var script = '';
-    if (sp.match(/https?:\/\/localhost:?\d*\/?$/)) {
-      script = 'powershell -noprofile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList \'-NoProfile -ExecutionPolicy Bypass -File "' +
-      path.join(cwd,'AppxUtilities/StartLh.ps1') +
-      ' ' + cwd + ' ' + guid + ' ' + manifestloc + '"\' -Verb Runas}";';
-    } else {
-      script = 'powershell -noprofile -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList \'-NoProfile -ExecutionPolicy Bypass -File "' +
-      path.join(cwd, 'AppxUtilities/Start.ps1') +
-      ' ' + cwd + ' ' + guid + ' ' + manifestloc + '"\'}";';
-    }
-
+    var isLocalhost = sp.match(/https?:\/\/localhost:?\d*\/?$/); 
+    
+    var script = 'powershell -noprofile -ExecutionPolicy Bypass -File "'
+                  + path.join(cwd, 'AppxUtilities/' + (isLocalhost ? 'StartLh.ps1' : 'Start.ps1')) + '"'
+                  + ' "' + cwd + '" "' + guid + '" "' + manifestloc + '"';
     return new Promise(function (resolve, reject) {
       exec(script, function(err, stdout, stderr) {
         if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hwa",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Hosted Web App Launcher",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
- Return promise from registerApp to notify callers when registration is complete
- Return error information when the app registration fails
- Fixes issue where PowerShell process never exits when executed in latest RS1 builds
- Bump version to v0.0.7
